### PR TITLE
fix: python3.7 no longer supported

### DIFF
--- a/CloudFormation/aws-backup-org-policy.yaml
+++ b/CloudFormation/aws-backup-org-policy.yaml
@@ -172,7 +172,7 @@ Resources:
       Description: Copy Solutions Binary to Local Cache Bucket
       Handler: index.lambda_handler
       Role : !GetAtt OrgPolicyCustomResourceManagerRole.Arn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 300
 
   rOrgBackUpPolicy:


### PR DESCRIPTION
To avoid error:

Resource handler returned message: "The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.12) while creating or updating functions. (Service: Lambda, Status Code: 400, Request ID: a7453eeb-141f-4eba-b7c6-c4d3d13788b3)" (RequestToken: b0ef37f6-ac4a-0325-6641-619dce0b26bf, HandlerErrorCode: InvalidRequest)